### PR TITLE
Fix Marshaling of Dialogue

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -288,6 +288,44 @@ var testcases = []struct {
 			return v, nil
 		},
 	}, {
+		description: "Dialogue/AARQ/UserInformation",
+		structured: tcap.NewDialogue(
+			1, 1, // OID, Version
+			tcap.NewAARQ(
+				// Version, Context, ContextVersion
+				1, tcap.AnyTimeInfoEnquiryContext, 3,
+				tcap.NewIE(0xBE, []byte{0xde, 0xad, 0xbe, 0xef}),
+			),
+			[]byte{0xde, 0xad, 0xbe, 0xef},
+		),
+		serialized: []byte{
+			0x6b, 0x28, 0x28, 0x26, 0x06, 0x07, 0x00, 0x11, 0x86, 0x05, 0x01, 0x01, 0x01, 0xa0, 0x17, 0x60,
+			0x15, 0x80, 0x02, 0x07, 0x80, 0xa1, 0x09, 0x06, 0x07, 0x04, 0x00, 0x00, 0x01, 0x00, 0x1d, 0x03,
+			0xbe, 0x04, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+		},
+		parseFunc: func(b []byte) (serializable, error) {
+			v, err := tcap.ParseDialogue(b)
+			if err != nil {
+				return nil, err
+			}
+
+			b, err = v.MarshalBinary()
+			if err != nil {
+				return nil, err
+			}
+
+			// Purposely do not clean v.SingleAsn1Type.Value the first time
+
+			v, err = tcap.ParseDialogue(b)
+			if err != nil {
+				return nil, err
+			}
+
+			v.SingleAsn1Type.Value = nil
+
+			return v, nil
+		},
+	}, {
 		description: "Dialogue/AARE",
 		structured: tcap.NewDialogue(
 			1, 1, // OID, Version

--- a/dialogue-pdu.go
+++ b/dialogue-pdu.go
@@ -700,7 +700,7 @@ func (d *DialoguePDU) ContextVersion() string {
 
 // String returns DialoguePDU in human readable string.
 func (d *DialoguePDU) String() string {
-	return fmt.Sprintf("{Type: %#x, Length: %d, ProtocolVersion: %v, ApplicationContextName: %v, Result: %v, ResultSourceDiagnostic: %v, AbortSource: %v}",
+	return fmt.Sprintf("{Type: %#x, Length: %d, ProtocolVersion: %v, ApplicationContextName: %v, Result: %v, ResultSourceDiagnostic: %v, AbortSource: %v, UserInformation: %v}",
 		d.Type,
 		d.Length,
 		d.ProtocolVersion,
@@ -708,5 +708,6 @@ func (d *DialoguePDU) String() string {
 		d.Result,
 		d.ResultSourceDiagnostic,
 		d.AbortSource,
+		d.UserInformation,
 	)
 }

--- a/tcap.go
+++ b/tcap.go
@@ -114,6 +114,7 @@ func Parse(b []byte) (*TCAP, error) {
 	if err := t.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
+
 	return t, nil
 }
 


### PR DESCRIPTION
Marshaling of Dialogue was incorrect.
Unmarshaling was filling both SingleAsn1Type and DialoguePDU, so marshaling back was writting both which is incorrect.

Issues found with unit tests were fixed, thanks :-)

Next PR is to support marshaling of nested/recursive IEs!